### PR TITLE
Applicative(ish) implemention, and unasume commutivity

### DIFF
--- a/src/main/scala/monadui/OutputAp.scala
+++ b/src/main/scala/monadui/OutputAp.scala
@@ -1,0 +1,100 @@
+package monadui
+
+object LiftOutputTuples {
+  import scala.language.experimental.macros
+  import scala.reflect.macros.blackbox.Context
+
+  def apply[M[_],T](expr: M[T]): M[T] =  macro liftTuplesImpl[M[T],T]
+
+  def liftTuplesImpl[MT : c.WeakTypeTag, T : c.WeakTypeTag](c: Context)(expr: c.Tree) = {
+
+    import c.universe._
+
+    val flatMapName = TermName("flatMap")
+    val mapName = TermName("map")
+
+    object OpsUnwrap {
+      val tc = weakTypeOf[MT].typeConstructor
+      def unapply(v: c.Tree) = v match {
+        case v if v.tpe.typeConstructor == tc ⇒ Some(v)
+        case q"$ops($inner)" if inner.tpe.typeConstructor == tc ⇒ Some(inner)
+        case _ ⇒ None
+      }
+    }
+
+    class TupleLiftingTransformer extends Transformer {
+      // Perhaps Nested flatMap
+      private object PN {
+        def unapply(tree: Tree): Option[Tree] = tree match {
+          case Apply(TypeApply(Select(wr@OpsUnwrap(vm), TermName("flatMap")), tOuter),
+                     (oldClosure@Function(vValDef :: Nil,
+                     PN(Apply(TypeApply(Select(OpsUnwrap(wm), inner : TermName), tInner),
+                     (oldInnerClosure@Function(wValDef :: Nil, expr)) :: Nil)))) :: Nil)
+            if (inner == flatMapName || inner == mapName) ⇒
+
+            val ap2 = q"${wr.tpe.typeSymbol.companion}.ap2"
+
+            // Crucial part: ensure that v is never used as the qualifier
+            val vUsed = wm.find(vValDef.symbol == _.symbol)
+            if (vUsed.isDefined) {
+              c.info(vUsed.get.pos, s"Not lifting, because ${vValDef.symbol} is used on rhs", true)
+              Some(TupleLiftingTransformer.super.transform(tree))
+            }
+
+            else {
+              val xexpr = transform(expr)
+              val qual = q"$ap2($vm, $wm)"
+
+              // Function parameter of type (V,W) for new closure
+              val vt = oldClosure.vparams.head.tpt.tpe
+              val wt = oldInnerClosure.vparams.head.tpt.tpe
+              val tupleOfXYtt: Tree = tq"($vt,$wt)"
+
+              // Assemble and type new combinator application:
+              val vwArgName = internal.reificationSupport.freshTermName("x$")
+              val vvd = c.internal.valDef(vValDef.symbol, q"$vwArgName._1")
+              val wvd = c.internal.valDef(wValDef.symbol, q"$vwArgName._2")
+              val ret = q"$qual.$inner[..$tInner]({$vwArgName : $tupleOfXYtt => {$vvd; $wvd; ..$xexpr}})"
+              val rett = c.typecheck(ret)
+
+              // Extract the new closure after typing, so we can fix ownership problems.
+              val Apply(_, newClosureTyped :: Nil) = rett
+              // The new closure belongs to whoever owned the old closure.
+              c.internal.setOwner(newClosureTyped.symbol, oldClosure.symbol.owner)
+              // The new parameters belong to the new closure.
+              c.internal.changeOwner(rett, vValDef.symbol.owner, newClosureTyped.symbol)
+              c.internal.changeOwner(rett, wValDef.symbol.owner, newClosureTyped.symbol)
+              // c.info(tree.pos, s"Lifting to $rett", true)
+              Some(rett)
+            }
+
+          // Boring map.  Possibly the inner of a nested map.  Actually, we don't bother to insist that
+          // it's a map/flatMap, since that will be done in the previous case.
+          case Apply(TypeApply(Select(wm, comb), _),
+          Function(_ :: Nil, _) :: Nil) ⇒
+            Some(TupleLiftingTransformer.super.transform(tree))
+
+          case t ⇒
+            None
+        }
+      }
+
+      override def transform(tree: Tree): Tree = tree match {
+        case PN(xformed) ⇒ xformed
+
+        case _ ⇒
+          super.transform(tree)
+      }
+
+    }
+
+    val ret =  (new TupleLiftingTransformer).transform(expr)
+
+    c.info(c.enclosingPosition, s"Converted to ${showCode(ret, printTypes=Some(false))}", true)
+
+    ret
+
+  }
+
+}
+

--- a/src/main/scala/monadui/OutputFlatMapDsl.scala
+++ b/src/main/scala/monadui/OutputFlatMapDsl.scala
@@ -26,5 +26,27 @@ object OutputFlatMapDsl {
       else output.withValue(None, HashMap.empty)
     }
     def withFilter(f: T => Boolean): Output[T] = filter(f)
+
+    def ap2[U](o2: Output[U]): Output[(T, U)] = {
+      val w = Output.mergeMultiMap(output.written, o2.written)
+      (output, o2) match {
+        case (Output(Some(v1), _), Output(Some(v2), _)) ⇒
+          new Output(Some((v1, v2)), w)
+        case _ ⇒
+          new Output(None, w)
+      }
+    }
+  }
+
+  object RichOutput {
+    def ap2[T1, T2](o1: Output[T1], o2: Output[T2]): Output[(T1,T2)] = {
+      val w = Output.mergeMultiMap(o1.written, o2.written)
+      (o1, o2) match {
+        case (Output(Some(v1), _), Output(Some(v2), _)) ⇒
+          new Output(Some((v1, v2)), w)
+        case _ ⇒
+          new Output(None, w)
+      }
+    }
   }
 }

--- a/src/test/scala/monadui/OutputTest.scala
+++ b/src/test/scala/monadui/OutputTest.scala
@@ -5,8 +5,8 @@ import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.collection.immutable.HashMap
 
-object OutputTestMain {
-  def main(args: Array[String]): Unit = {
+object OutputTestMain extends App {
+  override def main(args: Array[String]): Unit = {
     val o = new OutputTest
     import o._
     testFlatMapDsl
@@ -14,11 +14,12 @@ object OutputTestMain {
     testFlatMapMacroDsl
     testImplicitDsl
     testAsyncDsl
+    testApp
   }
 }
 
 class OutputTest {
-  val List(o1, o2, o3, o4, o5, o6, o7, o8, o9, o10) = (1 to 10).toList.map(i => Output(i, ("Source", "OutputTest")))
+  val List(o1, o2, o3, o4, o5, o6, o7, o8, o9, o10) = (1 to 10).toList.map(i => Output(i, ("Source", s"OutputTest$i")))
 
   def measureCodeSize(a: Any) = {
     val classPathEntry = Paths.get(a.getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
@@ -36,14 +37,14 @@ class OutputTest {
   case object testFlatMapDsl {
     measureCodeSize(this)
     import OutputFlatMapDsl._
-    val result = for (_1 <- o1; _2 <- o2; _3 <- o3; _4 <- o4; _5 <- o5; _6 <- o6; _7 <- o7; _8 <- o8; _9 <- o9; _10 <- o10) yield (_1 + _2 + _3 + _4 + _5 + _6 + _7 + _8 + _9 + _10)
+    val result = for (_1 <- o1; _2 <- o2; _3 <- o3; _4 <- o4; _5 <- o5; _6 <- o6; _7 <- o7; _8 <- o8; _9 <- o9; _10 <- o10) yield (_1 - _2 - _3 - _4 - _5 - _6 - _7 - _8 - _9 - _10)
     println(result)
   }
 
   case object testFlatMapDslWithoutIndyLambda {
     measureCodeSize(this)
     import OutputFlatMapDslWithoutIndyLambda._
-    val result = for (_1 <- o1; _2 <- o2; _3 <- o3; _4 <- o4; _5 <- o5; _6 <- o6; _7 <- o7; _8 <- o8; _9 <- o9; _10 <- o10) yield (_1 + _2 + _3 + _4 + _5 + _6 + _7 + _8 + _9 + _10)
+    val result = for (_1 <- o1; _2 <- o2; _3 <- o3; _4 <- o4; _5 <- o5; _6 <- o6; _7 <- o7; _8 <- o8; _9 <- o9; _10 <- o10) yield (_1 - _2 - _3 - _4 - _5 - _6 - _7 - _8 - _9 - _10)
     println(result)
   }
 
@@ -51,7 +52,7 @@ class OutputTest {
     measureCodeSize(this)
     import OutputFlatMapMacroDsl._
     val result = o1.flatMap(x => new Output[Int](None, HashMap.empty))
-    //val result = for (_1 <- o1; _2 <- o2; _3 <- o3; _4 <- o4; _5 <- o5; _6 <- o6; _7 <- o7; _8 <- o8; _9 <- o9; _10 <- o10) yield (_1 + _2 + _3 + _4 + _5 + _6 + _7 + _8 + _9 + _10)
+    //val result = for (_1 <- o1; _2 <- o2; _3 <- o3; _4 <- o4; _5 <- o5; _6 <- o6; _7 <- o7; _8 <- o8; _9 <- o9; _10 <- o10) yield (_1 - _2 - _3 - _4 - _5 - _6 - _7 - _8 - _9 - _10)
     println(result)
   }
 
@@ -59,7 +60,7 @@ class OutputTest {
     measureCodeSize(this)
     import OutputImplicitDsl._
     val result = writing { implicit scope =>
-      o1.get + o2.get + o3.get + o4.get + o5.get + o6.get + o7.get + o8.get + o9.get + o10.get
+      o1.get - o2.get - o3.get - o4.get - o5.get - o6.get - o7.get - o8.get - o9.get - o10.get
     }
     println(result)
   }
@@ -68,8 +69,19 @@ class OutputTest {
     measureCodeSize(this)
     import OutputAsyncDsl._
     val result = writing {
-      value(o1) + value(o2) + value(o3) + value(o4) + value(o5) + value(o6) + value(o7) + value(o8) + value(o9) + value(o10)
+      value(o1) - value(o2) - value(o3) - value(o4) - value(o5) - value(o6) - value(o7) - value(o8) - value(o9) - value(o10)
     }
+    println(result)
+  }
+
+  case object testApp {
+    measureCodeSize(this)
+    import OutputFlatMapDsl._
+    import LiftOutputTuples.apply
+    val result =
+      LiftOutputTuples {
+        for (_1 <- o1; _2 <- o2; _3 <- o3; _4 <- o4; _5 <- o5; _6 <- o6; _7 <- o7; _8 <- o8; _9 <- o9; _10 <- o10) yield (_1 - _2 - _3 - _4 - _5 - _6 - _7 - _8 - _9 - _10)
+      }
     println(result)
   }
 }


### PR DESCRIPTION
implement ap2(o1: Output[T1], o2: Output[T2]): Output[(T1,T2)] and convert nested calls to flatMap closures to calls to ap2 with nested arguments.
Also, change the example to subtract successive values, so it's obvious if the order is messed up.